### PR TITLE
feat: adopt standard CI workflow with canonical commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,31 @@ Thank you for your interest in contributing to Talos, the hardware abstraction l
 
 ## Development Setup
 
+### Prerequisites
+
+- Python 3.11 or higher
+- Poetry (recommended) or pip
+
+### Setup with Poetry (Recommended)
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/c-daly/talos.git
+   cd talos
+   ```
+
+2. Install dependencies:
+   ```bash
+   poetry install --with dev
+   ```
+
+3. Activate the virtual environment:
+   ```bash
+   poetry shell
+   ```
+
+### Setup with pip
+
 1. Clone the repository:
    ```bash
    git clone https://github.com/c-daly/talos.git
@@ -21,16 +46,48 @@ Thank you for your interest in contributing to Talos, the hardware abstraction l
    pip install -e ".[dev]"
    ```
 
+## CI Parity: Running All Checks Locally
+
+Before opening a pull request, run these commands to mirror the GitHub Actions CI pipeline:
+
+```bash
+poetry install --with dev
+poetry run ruff check src tests
+poetry run black --check src tests
+poetry run mypy src
+poetry run pytest --cov=talos --cov-report=term-missing --cov-report=xml --cov-fail-under=95
+```
+
+All checks must pass for your PR to be merged.
+
 ## Running Tests
 
+With Poetry:
+```bash
+poetry run pytest
+```
+
+With pip:
 ```bash
 pytest
 ```
 
+For coverage reporting:
+```bash
+poetry run pytest --cov=talos --cov-report=term-missing
+```
+
 ## Code Style
 
-We use `black` for code formatting and `ruff` for linting:
+We use `black` for code formatting and `ruff` for linting.
 
+With Poetry:
+```bash
+poetry run black src/ tests/
+poetry run ruff check src/ tests/
+```
+
+With pip:
 ```bash
 black src/ tests/
 ruff check src/ tests/
@@ -38,6 +95,12 @@ ruff check src/ tests/
 
 ## Type Checking
 
+With Poetry:
+```bash
+poetry run mypy src/
+```
+
+With pip:
 ```bash
 mypy src/
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Talos: Sensor/Actuator Abstraction Layer for Project LOGOS
 
+[![CI](https://github.com/c-daly/talos/actions/workflows/ci.yml/badge.svg)](https://github.com/c-daly/talos/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Overview


### PR DESCRIPTION
## Summary
This PR implements the CI parity requirements from issue #11 by documenting the canonical commands and adding CI status badges.

## Changes
- ✅ Added CI status badge to README
- ✅ Added "CI Parity" section to CONTRIBUTING.md with canonical commands
- ✅ Documented both Poetry (recommended) and pip workflows
- ✅ All checks pass locally:
  - `poetry run ruff check src tests` ✅
  - `poetry run black --check src tests` ✅
  - `poetry run mypy src` ✅
  - `poetry run pytest --cov=talos --cov-report=term-missing --cov-report=xml --cov-fail-under=95` ✅ (100% coverage)

## Notes
- The reusable workflow was already in place in `.github/workflows/ci.yml`
- README already had a "Local Testing (CI Parity)" section with correct commands
- No hardware-specific simulator blockers found
- All existing tests pass with 100% coverage

Resolves #11
Related to c-daly/apollo#32