### PR TITLE
[talos] Add shared integration stack helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,43 +38,37 @@ talos/
     └── shim.py       # Minimal executor that applies plan steps to Neo4j
 ```
 
-## Installation
+#### Integration Tests
 
-### Prerequisites
+Talos includes integration tests for external services like Milvus (vector database) and Neo4j. These tests validate:
 
-- Python 3.11 or higher
-- Poetry (recommended) or pip
+- Milvus collection initialization and configuration
+- Embedding storage and retrieval via sync utilities (simulating Hermes)
+- Metadata/UUID verification in Neo4j
+- Health checks and collection count assertions
 
-### Installing with Poetry (Recommended)
+Use the shared helper to bring up the LOGOS stack, wait for health, and run `pytest` in one step:
 
-Poetry provides better dependency management and reproducible builds.
+```bash
+cd /home/fearsidhe/projects/LOGOS/talos
+./scripts/run_integration_stack.sh                # defaults to pytest -m integration -v
+./scripts/run_integration_stack.sh tests/integration/test_executor_neo4j.py -v
+```
 
-1. **Install Poetry** (if not already installed):
-   ```bash
-   # Via pip
-   pip install poetry
-   
-   # Or via the official installer (recommended)
-   curl -sSL https://install.python-poetry.org | python3 -
-   ```
+Key environment overrides:
 
-2. **Clone the repository**:
-   ```bash
-   git clone https://github.com/c-daly/talos.git
-   cd talos
-   ```
+- `COMPOSE_FILE` – path to the LOGOS docker compose file (defaults to `../logos/infra/docker-compose.hcg.dev.yml`).
+- `REUSE_EXISTING_STACK=1` – skip `docker compose up` if you already have the stack running.
+- `KEEP_STACK_RUNNING=1` – leave services up after pytest completes.
+- `NEO4J_*` / `MILVUS_*` – override connection info used by the tests.
 
-3. **Install dependencies**:
-   ```bash
-   # Install all dependencies (including dev dependencies)
-   poetry install
-   
-   # Or install only production dependencies
-   poetry install --without dev
-   ```
+If you prefer bringing up services manually, ensure Neo4j and Milvus are running (see `docs/INTEGRATION_TESTING.md`) and then:
 
-4. **Activate the virtual environment**:
-   ```bash
+```bash
+poetry run pytest -m integration
+```
+
+To target a specific file or test, pass the usual pytest arguments either directly to `run_integration_stack.sh` or to `poetry run pytest` if the stack is already running.
    # Option 1: Spawn a shell within the virtual environment
    poetry shell
    

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -1,135 +1,131 @@
 # Integration Testing with LOGOS Infrastructure
 
-Talos integration tests use the shared LOGOS infrastructure for Neo4j and Milvus.
+Talos integration tests depend on the shared LOGOS HCG stack (Neo4j + Milvus). The
+repository now ships a helper script that mirrors the workflow used in Sophia and
+Hermes so contributors do not have to memorize Docker commands.
 
-## Prerequisites
+## Recommended Workflow: `scripts/run_integration_stack.sh`
 
-1. Start the LOGOS HCG development cluster:
 ```bash
-# From the LOGOS root directory
-cd /home/fearsidhe/projects/LOGOS/logos
-docker compose -f infra/docker-compose.hcg.dev.yml up -d
+cd /home/fearsidhe/projects/LOGOS/talos
+./scripts/run_integration_stack.sh                # starts stack + runs pytest -m integration -v
+./scripts/run_integration_stack.sh tests/integration/test_executor_neo4j.py -k grasp
 ```
 
-2. Verify services are running:
+The helper:
+
+1. Checks for port conflicts on 7474/7687/19530/9091 before starting services.
+2. Uses `docker compose ps -q` to locate the actual container IDs from
+	 `../logos/infra/docker-compose.hcg.dev.yml` (override with `COMPOSE_FILE`).
+3. Polls health (Neo4j) or running state (Milvus) with log tailing on failure.
+4. Exports the expected `NEO4J_*` / `MILVUS_*` variables, then runs pytest.
+
+### Environment Overrides
+
+| Variable | Description |
+| --- | --- |
+| `COMPOSE_FILE` | Path to the compose file (defaults to `../logos/infra/docker-compose.hcg.dev.yml`). |
+| `COMPOSE_CMD` | Change the compose binary, e.g. `COMPOSE_CMD="docker compose --project-name logos-hcg"`. |
+| `HEALTH_TIMEOUT` | Seconds to wait for each service before failing (default 180). |
+| `REUSE_EXISTING_STACK=1` | Skip `docker compose up`; assumes the stack is already running. |
+| `KEEP_STACK_RUNNING=1` | Leave services running after pytest completes. |
+| `RUN_TESTS=0` | Start the stack (and optionally keep it up) without invoking pytest. |
+| `PYTEST_BIN` | Override the pytest command (default `poetry run pytest`). |
+| `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD` | Connection info passed to tests. |
+| `MILVUS_HOST`, `MILVUS_PORT` | Milvus connection info (defaults to `localhost`/`19530`). |
+
+Examples:
+
 ```bash
+# Keep services running for manual debugging
+KEEP_STACK_RUNNING=1 ./scripts/run_integration_stack.sh
+
+# Reuse an existing stack and only run a subset of tests
+REUSE_EXISTING_STACK=1 ./scripts/run_integration_stack.sh tests/integration/test_milvus_comprehensive.py -k metadata
+
+# Bring up services but skip pytest (useful for local dev shells)
+RUN_TESTS=0 KEEP_STACK_RUNNING=1 ./scripts/run_integration_stack.sh
+```
+
+## Manual Workflow (Fallback)
+
+If you cannot use the helper, bring up the stack manually from the `logos` repo:
+
+```bash
+cd /home/fearsidhe/projects/LOGOS/logos
+docker compose -f infra/docker-compose.hcg.dev.yml up -d neo4j milvus-standalone
 docker compose -f infra/docker-compose.hcg.dev.yml ps
 ```
 
 Expected services:
 - `logos-hcg-neo4j` (ports 7474, 7687)
-- `logos-hcg-milvus` (port 19530)
+- `logos-hcg-milvus` (ports 19530, 9091)
 
-## Running Integration Tests
-
-### Run All Tests (Unit + Integration)
+Then, from the Talos repository:
 
 ```bash
-cd /home/fearsidhe/projects/LOGOS/talos
+# Run unit + integration tests
 poetry run pytest
-```
 
-### Run Only Unit Tests (No Infrastructure Required)
-
-```bash
-poetry run pytest -m "not integration"
-```
-
-### Run Only Integration Tests
-
-```bash
+# Only integration tests
 poetry run pytest -m integration
-```
 
-### Run Specific Integration Test Files
-
-```bash
-# Neo4j executor tests
+# Targeted files
 poetry run pytest tests/integration/test_executor_neo4j.py -v
-
-# Milvus tests  
 poetry run pytest tests/integration/test_milvus_comprehensive.py -v
-
-# Sensor suite tests
 poetry run pytest tests/integration/test_sensor_suite.py -v
-
-# E2E scenario tests
 poetry run pytest tests/integration/test_e2e_scenario.py -v
 ```
 
-## Environment Variables
+## Test Behavior & Coverage
 
-Integration tests use these environment variables (with defaults):
+- Tests marked `@pytest.mark.integration` automatically skip when services are unavailable.
+- Default environment variables:
 
-```bash
-# Neo4j configuration
-export NEO4J_URI="bolt://localhost:7687"
-export NEO4J_USERNAME="neo4j"
-export NEO4J_PASSWORD="logosdev"
+	```bash
+	export NEO4J_URI="bolt://localhost:7687"
+	export NEO4J_USERNAME="neo4j"
+	export NEO4J_PASSWORD="logosdev"
+	export MILVUS_HOST="localhost"
+	export MILVUS_PORT="19530"
+	```
 
-# Milvus configuration  
-export MILVUS_HOST="localhost"
-export MILVUS_PORT="19530"
-```
+- CI enforces **95%** coverage:
 
-## Test Behavior
-
-Integration tests automatically skip if services are unavailable:
-
-```
-SKIPPED [1] tests/integration/test_executor_neo4j.py:45: Neo4j not available
-```
-
-This allows CI to run unit tests without requiring infrastructure.
-
-## Coverage
-
-Run tests with coverage:
-
-```bash
-poetry run pytest --cov=talos --cov-report=term-missing --cov-report=xml
-```
-
-Target coverage: **95%**
+	```bash
+	poetry run pytest --cov=talos --cov-report=term-missing --cov-report=xml
+	```
 
 ## Troubleshooting
 
+### Script exits early
+
+- Port conflicts: the helper prints a warning. Stop the conflicting process or set
+	`REUSE_EXISTING_STACK=1` if you intentionally started a custom stack.
+- Health timeout: inspect the streamed logs printed by the script, then rerun.
+
 ### Tests Skip: "Neo4j not available"
 
-1. Check Neo4j is running:
 ```bash
 docker ps | grep neo4j
-```
-
-2. Test connection manually:
-```bash
 docker exec logos-hcg-neo4j cypher-shell -u neo4j -p logosdev "RETURN 1;"
 ```
 
 ### Tests Skip: "Milvus not available"
 
-1. Check Milvus is running:
 ```bash
 docker ps | grep milvus
-```
-
-2. Verify port is accessible:
-```bash
 nc -zv localhost 19530
 ```
 
 ### Clean Slate
 
-To reset test data:
-
 ```bash
-# Stop and remove volumes
 docker compose -f /home/fearsidhe/projects/LOGOS/logos/infra/docker-compose.hcg.dev.yml down -v
-
-# Restart fresh
 docker compose -f /home/fearsidhe/projects/LOGOS/logos/infra/docker-compose.hcg.dev.yml up -d
 ```
 
 ## CI/CD
 
-Integration tests are marked with `@pytest.mark.integration` and can be selectively run in CI pipelines.
+Integration tests are marked with `@pytest.mark.integration` and can be selectively run
+in CI pipelines. Use the helper locally to match CI expectations before opening a PR.

--- a/scripts/run_integration_stack.sh
+++ b/scripts/run_integration_stack.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DEFAULT_COMPOSE_FILE="$REPO_ROOT/../logos/infra/docker-compose.hcg.dev.yml"
+COMPOSE_CMD=${COMPOSE_CMD:-"docker compose"}
+COMPOSE_FILE=${COMPOSE_FILE:-"$DEFAULT_COMPOSE_FILE"}
+HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-180}
+PORTS_TO_CHECK=(
+  "7474:Neo4j HTTP"
+  "7687:Neo4j Bolt"
+  "19530:Milvus gRPC"
+  "9091:Milvus Metrics"
+)
+SERVICES=("neo4j" "milvus-standalone")
+KEEP_STACK_RUNNING=${KEEP_STACK_RUNNING:-0}
+REUSE_EXISTING_STACK=${REUSE_EXISTING_STACK:-0}
+RUN_TESTS=${RUN_TESTS:-1}
+PYTEST_BIN=${PYTEST_BIN:-"poetry run pytest"}
+# shellcheck disable=SC2206
+PYTEST_CMD=($PYTEST_BIN)
+
+info() {
+  echo "[info] $1"
+}
+
+warn() {
+  echo "[warn] $1"
+}
+
+error() {
+  echo "[error] $1" >&2
+}
+
+check_port_in_use() {
+  local port=$1
+  if command -v ss >/dev/null 2>&1; then
+    if ss -tulpn 2>/dev/null | grep -q ":${port} "; then
+      return 0
+    fi
+  elif command -v lsof >/dev/null 2>&1; then
+    if lsof -i ":${port}" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+container_id() {
+  local service=$1
+  local id=""
+  id=$($COMPOSE_CMD -f "$COMPOSE_FILE" ps -q "$service" 2>/dev/null | head -n1 || true)
+  echo "$id"
+}
+
+container_display_name() {
+  local container=$1
+  local name=""
+  name=$(docker inspect -f '{{.Name}}' "$container" 2>/dev/null | sed 's#^/##' || true)
+  echo "${name:-$container}"
+}
+
+has_healthcheck() {
+  local container=$1
+  local hc=""
+  hc=$(docker inspect -f '{{if .Config.Healthcheck}}true{{else}}false{{end}}' "$container" 2>/dev/null || true)
+  [[ "$hc" == "true" ]]
+}
+
+wait_for_container() {
+  local service=$1
+  local container_id=$2
+  local display_name=${3:-$2}
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  local expect_healthcheck=$4
+
+  while (( SECONDS < deadline )); do
+    local status=""
+    status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
+
+    case "$status" in
+      healthy)
+        info "$service ($display_name) is healthy"
+        return 0
+        ;;
+      running)
+        if [[ "$expect_healthcheck" == "false" ]]; then
+          info "$service ($display_name) is running without healthcheck"
+          return 0
+        fi
+        warn "$service ($display_name) is running but waiting for healthcheck"
+        ;;
+      unhealthy)
+        error "$service ($display_name) reported unhealthy"
+        docker logs "$container_id" --tail=200 || true
+        return 1
+        ;;
+      starting|"" )
+        info "$service ($display_name) still starting (status: ${status:-unknown})"
+        ;;
+      *)
+        warn "$service ($display_name) status: $status"
+        ;;
+    esac
+    sleep 5
+  done
+
+  error "$service ($display_name) did not become ready within ${HEALTH_TIMEOUT}s"
+  docker logs "$container_id" --tail=200 || true
+  return 1
+}
+
+cleanup() {
+  if [[ "$REUSE_EXISTING_STACK" == "1" ]]; then
+    return
+  fi
+  info "Stopping Talos integration services..."
+  $COMPOSE_CMD -f "$COMPOSE_FILE" down >/dev/null 2>&1 || true
+}
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  error "Compose file '$COMPOSE_FILE' not found. Override with COMPOSE_FILE=/path/to/docker-compose.hcg.dev.yml"
+  exit 1
+fi
+
+if [[ "$REUSE_EXISTING_STACK" != "1" && "$KEEP_STACK_RUNNING" != "1" ]]; then
+  trap cleanup EXIT
+fi
+
+if [[ "$REUSE_EXISTING_STACK" != "1" ]]; then
+  info "Checking ports before starting services..."
+  for mapping in "${PORTS_TO_CHECK[@]}"; do
+    port=${mapping%%:*}
+    label=${mapping#*:}
+    if check_port_in_use "$port"; then
+      warn "$label (port $port) already in use"
+    else
+      info "$label port $port is free"
+    fi
+  done
+
+  info "Starting Neo4j + Milvus via $COMPOSE_CMD -f $COMPOSE_FILE"
+  if ! $COMPOSE_CMD -f "$COMPOSE_FILE" up -d "${SERVICES[@]}"; then
+    error "Failed to start services"
+    $COMPOSE_CMD -f "$COMPOSE_FILE" logs --tail=200 || true
+    exit 1
+  fi
+else
+  info "Reusing existing stack defined in $COMPOSE_FILE"
+fi
+
+for service in "${SERVICES[@]}"; do
+  container=$(container_id "$service")
+  if [[ -z "$container" ]]; then
+    error "Unable to determine container ID for '$service'"
+    $COMPOSE_CMD -f "$COMPOSE_FILE" ps "$service" || true
+    exit 1
+  fi
+  display_name=$(container_display_name "$container")
+  if has_healthcheck "$container"; then
+    expect_health="true"
+  else
+    expect_health="false"
+  fi
+  if ! wait_for_container "$service" "$container" "$display_name" "$expect_health"; then
+    error "Aborting due to service failure: $service"
+    exit 1
+  fi
+done
+
+export NEO4J_URI=${NEO4J_URI:-"bolt://localhost:7687"}
+export NEO4J_USERNAME=${NEO4J_USERNAME:-"neo4j"}
+export NEO4J_PASSWORD=${NEO4J_PASSWORD:-"logosdev"}
+export MILVUS_HOST=${MILVUS_HOST:-"localhost"}
+export MILVUS_PORT=${MILVUS_PORT:-"19530"}
+
+if [[ "$RUN_TESTS" == "0" ]]; then
+  info "RUN_TESTS=0 set; skipping pytest execution"
+  exit 0
+fi
+
+default_pytest_args=("-m" "integration" "-v")
+if [[ $# -gt 0 ]]; then
+  pytest_args=("$@")
+else
+  pytest_args=("${default_pytest_args[@]}")
+fi
+
+info "Running Talos integration tests: ${PYTEST_CMD[*]} ${pytest_args[*]}"
+"${PYTEST_CMD[@]}" "${pytest_args[@]}"


### PR DESCRIPTION
## Summary
- add scripts/run_integration_stack.sh to manage the Neo4j + Milvus integration stack with port checks, health polling, and pytest invocation
- document the new workflow in README.md and docs/INTEGRATION_TESTING.md so contributors can reuse or keep the stack running with environment overrides
- align Talos with the shared LOGOS integration workflow used by Sophia and Hermes

## Testing
- poetry run pytest tests/test_actuator_feedback.py -k telemetry

Fixes #20.